### PR TITLE
add hint for missing package on Debian Wheezy

### DIFF
--- a/augeas
+++ b/augeas
@@ -29,7 +29,7 @@ description:
 version_added: "1.1"
 requirements:
   - augeas + lenses (augeas-lenses on Debian)
-  - augeas python bindings (python-augeas on Debian)
+  - augeas python bindings (python-augeas on Debian, note: on Debian Wheezy you also need to install libpython2.7, since python-augeas package wrongly does not list it as a requirement)
 options:
   command:
     required: false


### PR DESCRIPTION
the python-augeas itself does wrongly not depend on libpython2.7, so if
libpython2.7 is not yet installed, an 'import augeas' in python fails.
This could easily be solved by manually installing the missing package.

Hope this helps anybody, since I'm new to ansible, it took me some time to find out what's the cause of this module "not working" ;)
