### PR TITLE
Optimization of costly Augeas() invocation, so it doesn't load all modules

### DIFF
--- a/augeas
+++ b/augeas
@@ -112,7 +112,7 @@ if augeas:
     # This code is copied from current devel branch of python-augeas
 
     # check whether augeas library supports span
-    if augeas.Augeas().match('/augeas/span'):
+    if augeas.Augeas(flags=getattr(Augeas, 'NO_MODL_AUTOLOAD', 0)).match('/augeas/span'):
         if not hasattr(augeas.Augeas, 'span'):
             class Augeas(augeas.Augeas):
 


### PR DESCRIPTION
Initially I thought that the performance hit was from the Augeas invocation around the line 443, but further testing proved the problem was in completely different place.

Now the net speed of running the play with a single augeas task on localhost from over 1.2 sec to the 0.3 sec (and that includes all other overheads associated with invocation of ansible).