### PR TITLE
Use lenses on matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Requirements:
 Options:
   - `command`
       - required: when `commands` is not used
-      - choices: [`set`, `ins`, `rm`, `match`, `lensmatch`, `transform`, `load`]
+      - choices: [`set`, `ins`, `rm`, `match`, `transform`, `load`]
       - description:
 
-         Whether given path should be modified, inserted (ins command can be really used in multicommand mode), removed or matched. _lensmatch_ is an extended version of match (with slightly different usage), allowing to specify a lens to parse the file
+         Whether given path should be modified, inserted (ins command can be really used in multicommand mode), removed or matched.
 
         Command "match" passes results through "result" attribute - every item on this list is an object with "label" and "value" (check second example below). Other commands returns true in case of any modification (so this value is always equal to "changed" attribue - this make more sens in case of bulk execution)
 
@@ -21,7 +21,7 @@ Options:
 
   - `path`:
       - required: when any `command` is used
-      - description: Variable path. With `lensmatch`, it is the relative path within the file tree.
+      - description: Variable path. With `lens` and `file`, it is the relative path within the file tree.
   - `value`:
       - required: when `command = set`
       - description: Variable value.
@@ -34,10 +34,10 @@ Options:
       - choices: [`before`, `after`]
       - description: Position of node insertion against given `path`.
   - `lens`:
-     - required: when `command = lensmatch`
+     - required: false
      - description: Augeas lens to be loaded.
   - `file`:
-     - required: when `command = lensmatch`
+     - required: false
      - description: File to parse.
   - `commands`
       - required: when `command` is not used
@@ -100,12 +100,12 @@ Examples:
                                    load
                                    match "/files/home/paluh/programming/ansible/tests/sshd_config/AllowUsers/*"'
 
-  - Lensmatch example - Is just a simplified command to match against files in
+  - Extended match example - Is just a simplified command to match against files in
     non-standard locations. In particular, allows example above can be written
     more concisely.
 
         - name: Modify sshd_config in custom location
-          action: augeas commands="lensmatch" lens="sshd" file="/home/paluh/programming/ansible/tests/sshd_config" path="AllowUsers/*"
+          action: augeas commands="match" lens="sshd" file="/home/paluh/programming/ansible/tests/sshd_config" path="AllowUsers/*"
 
   - Insert example
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Requirements:
 Options:
   - `command`
       - required: when `commands` is not used
-      - choices: [`set`, `ins`, `rm`, `match`, `transform`, `load`]
+      - choices: [`set`, `ins`, `rm`, `match`, `lensmatch`, `transform`, `load`]
       - description:
 
-         Whether given path should be modified, inserted (ins command can be really used in multicommand mode), removed or matched.
+         Whether given path should be modified, inserted (ins command can be really used in multicommand mode), removed or matched. _lensmatch_ is an extended version of match (with slightly different usage), allowing to specify a lens to parse the file
 
         Command "match" passes results through "result" attribute - every item on this list is an object with "label" and "value" (check second example below). Other commands returns true in case of any modification (so this value is always equal to "changed" attribue - this make more sens in case of bulk execution)
 
@@ -21,7 +21,7 @@ Options:
 
   - `path`:
       - required: when any `command` is used
-      - description: Variable path.
+      - description: Variable path. With `lensmatch`, it is the relative path within the file tree.
   - `value`:
       - required: when `command = set`
       - description: Variable value.
@@ -33,6 +33,12 @@ Options:
       - default: 'after'
       - choices: [`before`, `after`]
       - description: Position of node insertion against given `path`.
+  - `lens`:
+     - required: when `command = lensmatch`
+     - description: Augeas lens to be loaded.
+  - `file`:
+     - required: when `command = lensmatch`
+     - description: File to parse.
   - `commands`
       - required: when `command` is not used
       - description: Execute many commands at once (some configuration entries have to be created/updated at once - it is impossible to split them across multiple "set" calls). Standard shell quoting is allowed (rember to escape all quotes inside pahts/values - check last example). Expected formats: "set PATH VALUE", "rm PATH" or "match PATH" (look into examples for more details). You can separate commands with any white characters (new lines, spaces etc.). Result is passed through `result` attribute and contains list of tuples: (command, command result).
@@ -93,6 +99,13 @@ Examples:
           action: augeas commands='transform "sshd" "incl" "/home/paluh/programming/ansible/tests/sshd_config"
                                    load
                                    match "/files/home/paluh/programming/ansible/tests/sshd_config/AllowUsers/*"'
+
+  - Lensmatch example - Is just a simplified command to match against files in
+    non-standard locations. In particular, allows example above can be written
+    more concisely.
+
+        - name: Modify sshd_config in custom location
+          action: augeas commands="lensmatch" lens="sshd" file="/home/paluh/programming/ansible/tests/sshd_config" path="AllowUsers/*"
 
   - Insert example
 

--- a/library/augeas.py
+++ b/library/augeas.py
@@ -410,6 +410,7 @@ def execute(augeas_instance, commands):
             if params['lens'] :
                 augeas_instance.transform(params['lens'], params['file'])
                 augeas_instance.load()
+                params['path'] = "/files%s/%s" % ( params['file'] , params['path'] )
             result = [{'label': s, 'value': augeas_instance.get(s)} for s in augeas_instance.match(**params)]
         results.append((command + ' ' + ' '.join(p if p else '""' for p in params.values()), result))
 

--- a/library/augeas.py
+++ b/library/augeas.py
@@ -277,7 +277,7 @@ def parse_commands(commands):
     COMMANDS = {
         'set': [path_parser, AnythingParser('value')],
         'rm': [path_parser],
-        'match': [path_parser],
+        'match': [path_parser, ParamParser('lens'), ParamParser('file')],
         'ins': [NonEmptyParser('label'), OneOfParser('where', ['before', 'after']), path_parser],
         'transform': [NonEmptyParser('lens'), OneOfParser('filter', ['incl', 'excl']), NonEmptyParser('file')],
         'load': []
@@ -465,7 +465,7 @@ def main():
         elif command == 'load':
             params = {}
         else: # rm or match
-            params = {'path': module.params['path']}
+            params = {'path': module.params['path'], 'lens': module.params['lens'], 'file': module.params['file'}
         commands = [(command, params)]
     else:
         try:

--- a/library/augeas.py
+++ b/library/augeas.py
@@ -407,6 +407,9 @@ def execute(augeas_instance, commands):
         elif command == 'load':
             augeas_instance.load()
         else: # match
+            if params['lens'] :
+                augeas_instance.transform(params['lens'], params['file'])
+                augeas_instance.load()
             result = [{'label': s, 'value': augeas_instance.get(s)} for s in augeas_instance.match(**params)]
         results.append((command + ' ' + ' '.join(p if p else '""' for p in params.values()), result))
 

--- a/library/augeas.py
+++ b/library/augeas.py
@@ -33,13 +33,13 @@ requirements:
 options:
   command:
     required: false
-    choices: [ set, ins, rm, match ]
+    choices: [ set, ins, rm, match, lensmatch ]
     description:
-      - 'Whether given path should be modified, inserted, removed or matched. Command "match" passes results through "result" attribute - every item on this list is an object with "label" and "value" (check third example below). Other commands returns true in case of any modification (so this value is always equal to "changed" attribue - this make more sens in case of bulk execution)'
+      - 'Whether given path should be modified, inserted, removed or matched. Command "match" (and "lensmatch") passes results through "result" attribute - every item on this list is an object with "label" and "value" (check third example below). Other commands returns true in case of any modification (so this value is always equal to "changed" attribue - this make more sens in case of bulk execution)'
   path:
     required: false
     description:
-      - 'Variable path.'
+      - 'Variable path. With `lensmatch`, it is the relative path within the file tree.'
   value:
     required: false
     description:
@@ -53,6 +53,14 @@ options:
     choices: [before, after]
     description:
       - 'Position of node insertion against given path.'
+  lens:
+    required: false
+    description:
+      - 'Augeas lens to be loaded.'
+  file:
+    required: false
+    description:
+      - 'File to parse.'
   commands:
     required: false
     description:
@@ -77,6 +85,9 @@ examples:
         action: augeas command="set" path="/files/etc/ssh/sshd_config/AllowUsers/01" value="{{ user }}"
         when: "user_entry.result|length == 0"
     description: "Quite complex modification - fetch values lists and append new value only if it doesn't exists already in config"
+
+  - code: 'action: augeas commands="lensmatch" lens="sshd" file="/home/paluh/programming/ansible/tests/sshd_config" path="AllowUsers/*"'
+    description: Modify sshd_config in custom location
 
   - code: |
       - name: Add new host to /etc/hosts

--- a/library/augeas.py
+++ b/library/augeas.py
@@ -408,9 +408,9 @@ def execute(augeas_instance, commands):
             augeas_instance.load()
         else: # match
             if params['lens'] :
-                augeas_instance.transform(params['lens'], params['file'])
+                augeas_instance.transform(params.pop('lens'), params['file'])
                 augeas_instance.load()
-                params['path'] = "/files%s/%s" % ( params['file'] , params['path'] )
+                params['path'] = "/files%s/%s" % ( params.pop('file') , params['path'] )
             result = [{'label': s, 'value': augeas_instance.get(s)} for s in augeas_instance.match(**params)]
         results.append((command + ' ' + ' '.join(p if p else '""' for p in params.values()), result))
 


### PR DESCRIPTION
Add a lensmatch command which combines a transform and a match. This is useful to parse files not autodetected by augeas, such as parseable files in non standard locations, or files not "declared" to augeas (for example, /etc/ansible/ansible.cfg, parseable with puppet lens).

It is a new command because I've not been able to turn lens & file into optional parameters for standard match.