### PR TITLE
Add "edit" command

### DIFF
--- a/library/augeas.py
+++ b/library/augeas.py
@@ -433,13 +433,16 @@ def execute(augeas_instance, commands):
                 path += '/#comment[ . =~ regexp("%s( |=).*") ]' % label
             else:
                 path = params['path']
+            result = changed = False
             node = augeas_instance.match("%s/%s" % (os.path.dirname(path), label))
             if not node:
                 try:
                     node = [ augeas_instance.insert(path, label, False) ]
+                    result = changed = True
                 except ValueError:
                     try:
                         node = [ augeas_instance.insert(params['path'], label, False) ]
+                        result = changed = True
                     except ValueError:
                         raise InsertError(command, params, augeas_instance)
             path = "%s/%s" % (os.path.dirname(path), label)
@@ -450,8 +453,6 @@ def execute(augeas_instance, commands):
                 except ValueError:
                     raise SetError(command, params, augeas_instance)
                 result = changed = True
-            else:
-                result = False
         elif command == 'transform':
             excl = params['filter'] == 'excl'
             augeas_instance.transform(lens, file_, excl)

--- a/library/augeas.py
+++ b/library/augeas.py
@@ -464,6 +464,7 @@ def main():
             commands=dict(default=None),
             where=dict(default=None),
             label=dict(default=None),
+            comment=dict(default=False, type='bool'),
             lens=dict(default=None),
             file=dict(defulat=None),
             filter=dict(default=None)
@@ -482,6 +483,8 @@ def main():
     commands = None
     if module.params['command'] is not None:
         command = module.params['command']
+        if module.params['comment'] and command not in ('ins', 'edit'):
+            module.fail_json(msg='You can only set "comment" with "ins" or "edit" commands.')
         if command == 'set':
             if module.params['value'] is None:
                 module.fail_json(msg='You should use "value" argument with "set" command.')
@@ -501,7 +504,7 @@ def main():
             if module.params['value'] is None:
                 module.fail_json(msg='You have to use "value" argument with "edit" command.')
             params = {'label': module.params['label'], 'path': module.params['path'],
-                      'value': module.params['value']}
+                      'value': module.params['value'], 'comment': module.params['comment']}
         elif command == 'transform':
             params = {'lens': module.params['lens'], 'file': module.params['file'],
                       'filter': module.params['filter']}

--- a/library/augeas.py
+++ b/library/augeas.py
@@ -509,7 +509,8 @@ def main():
             if module.params['path'] is None:
                 module.fail_json(msg='You have to use "path" argument with "ins" command.')
             params = {'label': module.params['label'], 'path': module.params['path'],
-                      'where': module.params['where'] or 'before'}
+                      'where': module.params['where'] or 'before',
+                      'comment': module.params['comment']}
         elif command == 'edit':
             if module.params['label'] is None:
                 module.fail_json(msg='You have to use "label" argument with "edit" command.')

--- a/library/augeas.py
+++ b/library/augeas.py
@@ -292,6 +292,7 @@ def parse_commands(commands):
         'match': [path_parser],
         'ins': [NonEmptyParser('label'), OneOfParser('where', ['before', 'after']), path_parser],
         'transform': [NonEmptyParser('lens'), OneOfParser('filter', ['incl', 'excl']), NonEmptyParser('file')],
+        'edit': [NonEmptyParser('label'), AnythingParser('value'), path_parser, AnythingParser('lens'), AnythingParser('file')],
         'load': []
     }
     try:
@@ -438,7 +439,7 @@ def main():
         argument_spec=dict(
             loadpath=dict(default=None),
             root=dict(default=None),
-            command=dict(required=False, choices=['set', 'rm', 'match', 'ins', 'transform', 'load']),
+            command=dict(required=False, choices=['set', 'rm', 'match', 'ins', 'edit', 'transform', 'load']),
             path=dict(aliases=['name', 'context']),
             value=dict(default=None),
             commands=dict(default=None),

--- a/library/augeas.py
+++ b/library/augeas.py
@@ -517,8 +517,6 @@ def main():
                 module.fail_json(msg='You have to use "label" argument with "edit" command.')
             if module.params['path'] is None:
                 module.fail_json(msg='You have to use "path" argument with "edit" command.')
-            if module.params['value'] is None:
-                module.fail_json(msg='You have to use "value" argument with "edit" command.')
             params = {'label': module.params['label'], 'path': module.params['path'],
                       'value': module.params['value'], 'comment': module.params['comment']}
         elif command == 'transform':

--- a/library/augeas.py
+++ b/library/augeas.py
@@ -421,7 +421,10 @@ def execute(augeas_instance, commands):
             try:
                 augeas_instance.insert(path, label, where == 'before')
             except ValueError:
-                raise InsertError(command, params, augeas_instance)
+                try:
+                    augeas_instance.insert(params['path'], label, where == 'before')
+                except ValueError:
+                    raise InsertError(command, params, augeas_instance)
             result = changed = True
         elif command == 'edit':
             label = params['label']
@@ -435,7 +438,10 @@ def execute(augeas_instance, commands):
                 try:
                     node = [ augeas_instance.insert(path, label, False) ]
                 except ValueError:
-                    raise InsertError(command, params, augeas_instance)
+                    try:
+                        node = [ augeas_instance.insert(params['path'], label, False) ]
+                    except ValueError:
+                        raise InsertError(command, params, augeas_instance)
             path = "%s/%s" % (os.path.dirname(path), label)
             value = params['value']
             if augeas_instance.get(path) != value:


### PR DESCRIPTION
This change adds an "edit" command, which is basically an ins+set. The main changes respect to the use of both commands in sequence is that the node is not inserted if it already exists (so, "edit" is not usable for labels with multiple entries). And it also adds a "comment" flag which search for a comment with the label on it, and insert the new node after it. This means that

    command=edit label=remote_user comment=True ...

will insert the node after

    # remote_user = ...

if that line exists, and after path if not. I've used this only on _.ini_ files up to now, but should work in the general case.