### PR TITLE
Make the augeas module work with mitogen

### DIFF
--- a/library/augeas.py
+++ b/library/augeas.py
@@ -440,6 +440,7 @@ def execute(augeas_instance, commands):
     return results, changed
 
 def main():
+    from ansible.module_utils.basic import AnsibleModule
     module = AnsibleModule(
         argument_spec=dict(
             loadpath=dict(default=None),


### PR DESCRIPTION
- This is a simple one-liner fix, it makes ansible-augeas compatible with Mitogen for Ansible (https://mitogen.networkgenomics.com/ansible_detailed.html).
- It still works just fine with the Ansiballz framework.

Thank you for the module :+1: :heart_eyes: 