### PR TITLE
Fix to use transform in the commands parameter

### DIFF
--- a/library/augeas.py
+++ b/library/augeas.py
@@ -384,8 +384,8 @@ def execute(augeas_instance, commands):
         if 'lens' in params and 'file' in params:
             lens = params['lens']
             file_ = params['file']
-            params['path'] = "/files%s/%s" % (file_, params['path'])
             if command != 'transform':
+                params['path'] = "/files%s/%s" % (file_, params['path'])
                 augeas_instance.transform(lens, file_)
                 augeas_instance.load()
         if command == 'set':


### PR DESCRIPTION
When using transform in the commands parameter, the parameters lens and file are derived from its arguments. The path parameter is not and cannot be used, but the code attempts to access it. This patch fixes that.