### PR TITLE
remove needless and problematic -tt option

### DIFF
--- a/library/augeas.py
+++ b/library/augeas.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Tomasz Rybarczyk <paluho@gmail.com>


### PR DESCRIPTION
In python2, -tt caused python to abort if you mixed literal tabs and spaces. In python3, it is gone.

When running an ansible playbook on ansible 12 / Debian 13, the first play using this library threw an error:

    The module interpreter '/usr/bin/python3 -tt' was not found.
    Consider overriding the configured interpreter path for this host.
    See stdout/stderr for the returned output.

I speculate this is because it is doing

    subprocess.run(["/usr/bin/python3 -tt", ⋯], ⋯)

when it should be doing

    subprocess.run(["/usr/bin/python3", "-tt", ⋯], ⋯)

I confirmed that on both host (D13) and target (D12), the latter actually works just fine.

Since this argument is useless, just remove it.
This fixes the problem with no further diagnosis needed.